### PR TITLE
Refactor 'Script' to 'Command'

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
 		"commands": [
 			{
 				"category": "Mongo",
-				"command": "mongo.execute",
-				"title": "Execute Script"
+				"command": "mongo.executeCommand",
+				"title": "Execute Command"
 			},
 			{
 				"category": "Mongo",
@@ -141,7 +141,7 @@
 		"menus": {
 			"editor/context": [
 				{
-					"command": "mongo.execute",
+					"command": "mongo.executeCommand",
 					"when": "resourceLangId==mongo"
 				},
 				{
@@ -193,7 +193,7 @@
 		},
 		"keybindings": [
 			{
-				"command": "mongo.execute",
+				"command": "mongo.executeCommand",
 				"key": "ctrl+shift+'",
 				"mac": "cmd+shift+'",
 				"when": "editorLangId == 'mongo' && editorTextFocus"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,14 +10,14 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { MongoExplorer } from './mongo/explorer';
 import { MongoCommands } from './mongo/commands';
-import { Model, Database, Server, IMongoResource, MongoScript, Collection } from './mongo/mongo';
+import { Model, Database, Server, IMongoResource, MongoCommand, Collection } from './mongo/mongo';
 import MongoDBLanguageClient from './mongo/languageClient';
 
 let connectedDb: Database = null;
 let languageClient: MongoDBLanguageClient = null;
 let model: Model;
 let mongoDocumentCounter = 0;
-let lastScript: MongoScript;
+let lastCommand: MongoCommand;
 
 export function activate(context: vscode.ExtensionContext) {
 	// Create the storage folder
@@ -51,12 +51,12 @@ export function activate(context: vscode.ExtensionContext) {
 				vscode.workspace.openTextDocument(uri)
 					.then(textDocument => vscode.window.showTextDocument(textDocument));
 			}));
-			context.subscriptions.push(vscode.commands.registerCommand('mongo.execute', () => lastScript = MongoCommands.executeScriptFromActiveEditor(connectedDb)));
-			context.subscriptions.push(vscode.commands.registerCommand('mongo.updateDocuments', () => MongoCommands.updateDocuments(connectedDb, lastScript)));
+			context.subscriptions.push(vscode.commands.registerCommand('mongo.executeCommand', () => lastCommand = MongoCommands.executeCommandFromActiveEditor(connectedDb)));
+			context.subscriptions.push(vscode.commands.registerCommand('mongo.updateDocuments', () => MongoCommands.updateDocuments(connectedDb, lastCommand)));
 			context.subscriptions.push(vscode.commands.registerCommand('mongo.openCollection', (collection: Collection) => {
 				connectToDatabase(collection.db);
-				lastScript = MongoCommands.getMongoScript(`db.${collection.label}.find()`);
-				MongoCommands.executeScript(lastScript, connectedDb).then(result => MongoCommands.showResult(result));
+				lastCommand = MongoCommands.getCommand(`db.${collection.label}.find()`);
+				MongoCommands.executeCommand(lastCommand, connectedDb).then(result => MongoCommands.showResult(result));
 			}));
 		});
 	}

--- a/src/mongo/commands.ts
+++ b/src/mongo/commands.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { ParseTree } from 'antlr4ts/tree/ParseTree';
 import { ANTLRInputStream as InputStream } from 'antlr4ts/ANTLRInputStream';
 import { CommonTokenStream } from 'antlr4ts/CommonTokenStream';
-import { Model, Server, Database, MongoScript } from './mongo';
+import { Model, Server, Database, MongoCommand } from './mongo';
 import * as fs from 'fs';
 import * as mongoParser from './../grammar/mongoParser';
 import { MongoVisitor } from './../grammar/visitors';
@@ -15,24 +15,24 @@ import { mongoLexer } from './../grammar/mongoLexer';
 
 export class MongoCommands {
 
-	public static executeScriptFromActiveEditor(database: Database): MongoScript {
+	public static executeCommandFromActiveEditor(database: Database): MongoCommand {
 		const activeEditor = vscode.window.activeTextEditor;
 		if (activeEditor.document.languageId !== 'mongo') {
 			return;
 		}
 		const selection = activeEditor.selection;
-		const script = MongoCommands.getMongoScript(activeEditor.document.getText(), selection.start);
-		MongoCommands.executeScript(script, database)
+		const command = MongoCommands.getCommand(activeEditor.document.getText(), selection.start);
+		MongoCommands.executeCommand(command, database)
 			.then(result => this.showResult(result, activeEditor.viewColumn + 1));
-		return script;
+		return command;
 	}
 
-	public static executeScript(script: MongoScript, database: Database): Thenable<string> {
+	public static executeCommand(command: MongoCommand, database: Database): Thenable<string> {
 		if (!database) {
 			vscode.window.showErrorMessage('Please connect to the database first');
 			return;
 		}
-		return database.executeScript(script)
+		return database.executeCommand(command)
 			.then(result => result, error => vscode.window.showErrorMessage(error));
 	}
 
@@ -54,7 +54,7 @@ export class MongoCommands {
 			});
 	}
 
-	public static updateDocuments(database: Database, script: MongoScript): void {
+	public static updateDocuments(database: Database, command: MongoCommand): void {
 		if (!database) {
 			vscode.window.showErrorMessage('Please connect to the database first');
 			return;
@@ -62,7 +62,7 @@ export class MongoCommands {
 
 		const editor = vscode.window.activeTextEditor;
 		const documents = JSON.parse(editor.document.getText());
-		database.updateDocuments(documents, script.collection)
+		database.updateDocuments(documents, command.collection)
 			.then(result => {
 				editor.edit(editorBuilder => {
 					if (editor.document.lineCount > 0) {
@@ -74,71 +74,70 @@ export class MongoCommands {
 			});
 	}
 
-	public static getMongoScript(content: string, position?: vscode.Position): MongoScript {
+	public static getCommand(content: string, position?: vscode.Position): MongoCommand {
 		const lexer = new mongoLexer(new InputStream(content));
 		lexer.removeErrorListeners();
 		const parser = new mongoParser.mongoParser(new CommonTokenStream(lexer));
 		parser.removeErrorListeners();
 
-		const scripts = new MongoScriptDocumentVisitor().visit(parser.commands());
-		let lastScriptOnSameLine = null;
-		let lastScriptBeforePosition = null;
+		const commands = new MongoScriptDocumentVisitor().visit(parser.commands());
+		let lastCommandOnSameLine = null;
+		let lastCommandBeforePosition = null;
 		if (position) {
-			for (const script of scripts) {
-				if (script.range.contains(position)) {
-					return script;
+			for (const command of commands) {
+				if (command.range.contains(position)) {
+					return command;
 				}
-				if (script.range.end.line === position.line) {
-					lastScriptOnSameLine = script;
+				if (command.range.end.line === position.line) {
+					lastCommandOnSameLine = command;
 				}
-				if (script.range.end.isBefore(position)) {
-					lastScriptBeforePosition = script;
+				if (command.range.end.isBefore(position)) {
+					lastCommandBeforePosition = command;
 				}
 			}
 		}
-		return lastScriptOnSameLine || lastScriptBeforePosition || scripts[scripts.length - 1];
+		return lastCommandOnSameLine || lastCommandBeforePosition || commands[commands.length - 1];
 	}
 }
 
-export class MongoScriptDocumentVisitor extends MongoVisitor<MongoScript[]> {
+export class MongoScriptDocumentVisitor extends MongoVisitor<MongoCommand[]> {
 
-	private mongoScripts: MongoScript[] = [];
+	private commands: MongoCommand[] = [];
 
-	visitCommand(ctx: mongoParser.CommandContext): MongoScript[] {
-		this.mongoScripts.push({
+	visitCommand(ctx: mongoParser.CommandContext): MongoCommand[] {
+		this.commands.push({
 			range: new vscode.Range(ctx.start.line - 1, ctx.start.charPositionInLine, ctx.stop.line - 1, ctx.stop.charPositionInLine),
-			script: ctx.text,
-			command: ''
+			text: ctx.text,
+			name: ''
 		});
 		return super.visitCommand(ctx);
 	}
 
-	visitCollection(ctx: mongoParser.CollectionContext): MongoScript[] {
-		this.mongoScripts[this.mongoScripts.length - 1].collection = ctx.text;
+	visitCollection(ctx: mongoParser.CollectionContext): MongoCommand[] {
+		this.commands[this.commands.length - 1].collection = ctx.text;
 		return super.visitCollection(ctx);
 	}
 
-	visitFunctionCall(ctx: mongoParser.FunctionCallContext): MongoScript[] {
+	visitFunctionCall(ctx: mongoParser.FunctionCallContext): MongoCommand[] {
 		if (ctx.parent instanceof mongoParser.CommandContext) {
-			this.mongoScripts[this.mongoScripts.length - 1].command = ctx._FUNCTION_NAME.text;
+			this.commands[this.commands.length - 1].name = ctx._FUNCTION_NAME.text;
 		}
 		return super.visitFunctionCall(ctx);
 	}
 
-	visitArgumentList(ctx: mongoParser.ArgumentListContext): MongoScript[] {
+	visitArgumentList(ctx: mongoParser.ArgumentListContext): MongoCommand[] {
 		let argumentsContext = ctx.parent;
 		if (argumentsContext) {
 			let functionCallContext = argumentsContext.parent;
 			if (functionCallContext && functionCallContext.parent instanceof mongoParser.CommandContext) {
-				this.mongoScripts[this.mongoScripts.length - 1].arguments = ctx.text;
+				this.commands[this.commands.length - 1].arguments = ctx.text;
 			}
 		}
 		return super.visitArgumentList(ctx);
 	}
 
-	protected defaultResult(node: ParseTree): MongoScript[] {
-		return this.mongoScripts;
+	protected defaultResult(node: ParseTree): MongoCommand[] {
+		return this.commands;
 	}
-
 }
 

--- a/src/mongo/mongo.ts
+++ b/src/mongo/mongo.ts
@@ -12,11 +12,11 @@ import { MongoClient, Db, ReadPreference, Code, Server as MongoServer, Collectio
 import { Shell } from './shell';
 import { EventEmitter, Event, Command } from 'vscode';
 
-export interface MongoScript {
+export interface MongoCommand {
 	range: vscode.Range;
-	script: string;
+	text: string;
 	collection?: string;
-	command: string;
+	name: string;
 	arguments?: string;
 }
 
@@ -272,22 +272,26 @@ export class Database implements IMongoResource {
 			});
 	}
 
-	executeScript(script: MongoScript): Thenable<string> {
-		if (script.collection) {
+	executeCommand(command: MongoCommand): Thenable<string> {
+		if (command.collection) {
 			return this.getDb()
 				.then(db => {
-					const collection = db.collection(script.collection);
+					const collection = db.collection(command.collection);
 					if (collection) {
-						const result = new Collection(collection, this).executeCommand(script.command, script.arguments);
+						const result = new Collection(collection, this).executeCommand(command.name, command.arguments);
 						if (result) {
 							return result;
 						}
 					}
-					return reportProgress(this.executeScriptInShell(script), 'Executing script');
+					return reportProgress(this.executeCommandInShell(command), 'Executing command');
 				});
 		}
-		const result = this.executeCommand(script.command, script.arguments);
-		return result ? result : reportProgress(this.executeScriptInShell(script), 'Executing script');
+
+		if (command.name === 'createCollection') {
+			return reportProgress(this.createCollection(stripQuotes(command.arguments)).then(() => JSON.stringify({ 'Created': 'Ok' })), 'Creating collection');
+		} else {
+			return reportProgress(this.executeCommandInShell(command), 'Executing command');
+		}
 	}
 
 	updateDocuments(documentOrDocuments: any, collectionName: string): Thenable<string> {
@@ -329,19 +333,8 @@ export class Database implements IMongoResource {
 		return this.getDb().then(db => new Collection(db.collection(collection), this));
 	}
 
-	executeScriptInShell(script: MongoScript): Thenable<string> {
-		return this.getShell().then(shell => shell.exec(script.script));
-	}
-
-	executeCommand(command: string, args?: string): Thenable<string> {
-		try {
-			if (command === 'createCollection') {
-				return reportProgress(this.createCollection(stripQuotes(args)).then(() => JSON.stringify({ 'Created': 'Ok' })), 'Creating collection');
-			}
-			return null;
-		} catch (error) {
-			return Promise.resolve(error);
-		}
+	executeCommandInShell(command: MongoCommand): Thenable<string> {
+		return this.getShell().then(shell => shell.exec(command.text));
 	}
 
 	private getShell(): Promise<Shell> {
@@ -391,33 +384,33 @@ export class Collection implements IMongoResource {
 		title: ''
 	};
 
-	executeCommand(command: string, args?: string): Thenable<string> {
+	executeCommand(name: string, args?: string): Thenable<string> {
 		try {
-			if (command === 'find') {
+			if (name === 'find') {
 				return reportProgress(this.find(args ? parseJSContent(args) : undefined), 'Running find query');
 			}
-			if (command === 'drop') {
+			if (name === 'drop') {
 				return reportProgress(this.drop(), 'Dropping collection');
 			}
-			if (command === 'findOne') {
+			if (name === 'findOne') {
 				return reportProgress(this.findOne(args ? parseJSContent(args) : undefined), 'Running find query');
 			}
-			if (command === 'insertMany') {
+			if (name === 'insertMany') {
 				return reportProgress(this.insertMany(args ? parseJSContent(args) : undefined), 'Inserting documents');
 			}
-			if (command === 'insert') {
+			if (name === 'insert') {
 				return reportProgress(this.insert(args ? parseJSContent(args) : undefined), 'Inserting document');
 			}
-			if (command === 'insertOne') {
+			if (name === 'insertOne') {
 				return reportProgress(this.insertOne(args ? parseJSContent(args) : undefined), 'Inserting document');
 			}
-			if (command === 'deleteOne') {
+			if (name === 'deleteOne') {
 				return reportProgress(this.deleteOne(args ? parseJSContent(args) : undefined), 'Deleting document');
 			}
-			if (command === 'deleteMany') {
+			if (name === 'deleteMany') {
 				return reportProgress(this.deleteMany(args ? parseJSContent(args) : undefined), 'Deleting documents');
 			}
-			if (command === 'remove') {
+			if (name === 'remove') {
 				return reportProgress(this.remove(args ? parseJSContent(args) : undefined), 'Removing');
 			}
 			return null;


### PR DESCRIPTION
'Execute Script' implies it will run the entire file, but that is not the case with the current implementation. It only executes a single 'Command'.

In the future, we can add 'Execute All Commands' to the context menu to reduce any possible ambiguity